### PR TITLE
Implemented reverse geocoding in RoundService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -44,6 +44,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'javax.validation:validation-api:2.0.1.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     
     // H2 for local development and tests

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/RestTemplateConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package ch.uzh.ifi.hase.soprafs26.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    // Add this new Bean so Spring always knows how to provide an ObjectMapper!
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Answer.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Answer.java
@@ -83,14 +83,14 @@ public class Answer {
      * - CORRECT_COUNTRY: <= 1000km (Yields 0 - 1000 points based on closeness)
      * - INCORRECT: > 1000km (Yields 0 points)
      */
-    public void calculateScoreBasedOnDistance(ScoringService scoringService) {
+public void calculateScoreBasedOnDistance(ScoringService scoringService) {
+        // Pass 'this.round' to allow service to access TargetCity and TargetCountry
         this.pointsAwarded = scoringService.calculateScore(
-            this.latitude, this.longitude,
-            this.round.getTargetLatitude(), this.round.getTargetLongitude()
+            this.latitude, this.longitude, this.round
         );
+        
         this.scoreResult = scoringService.getScoreResult(
-            this.latitude, this.longitude,
-            this.round.getTargetLatitude(), this.round.getTargetLongitude()
+            this.latitude, this.longitude, this.round
         );
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Round.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Round.java
@@ -27,6 +27,12 @@ public class Round {
     @Column
     private Instant startedAt;
 
+    @Column
+    private String targetCity;
+
+    @Column
+    private String targetCountry;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "ROUND_IMAGES", joinColumns = @JoinColumn(name = "round_id"))
     @Column(name = "image_url", length = 1000) // URLs can be long
@@ -47,4 +53,8 @@ public class Round {
     public void setFinished(boolean finished) { this.finished = finished; }
     public Instant getStartedAt() { return startedAt; }
     public void setStartedAt(Instant startedAt) { this.startedAt = startedAt; }
+    public String getTargetCity() { return targetCity; }
+    public void setTargetCity(String targetCity) { this.targetCity = targetCity; }
+    public String getTargetCountry() { return targetCountry; }
+    public void setTargetCountry(String targetCountry) { this.targetCountry = targetCountry; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/LocationResult.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/LocationResult.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class LocationResult {
+    private final String city;
+    private final String country;
+
+    public LocationResult(String city, String country) {
+        this.city = city;
+        this.country = country;
+    }
+
+    public String getCity() { return city; }
+    public String getCountry() { return country; }
+    public String getFullName() { return city + ", " + country; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -79,8 +79,8 @@ public interface DTOMapper {
     @Mapping(source = "round.id", target = "roundId")
     @Mapping(source = "round.targetLatitude", target = "correctLatitude")
     @Mapping(source = "round.targetLongitude", target = "correctLongitude")
-    @Mapping(target = "correctCity", constant = "Mystery City") // Placeholder since we skipped Geocoding
-    @Mapping(target = "correctCountry", constant = "Mystery Country") // Placeholder
+@Mapping(source = "round.targetCity", target = "correctCity")
+    @Mapping(source = "round.targetCountry", target = "correctCountry") 
     @Mapping(source = "standings", target = "standings")
     RoundSummaryGetDTO convertToRoundSummaryGetDTO(Round round, List<ScoringService.PlayerStanding> standings);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GeocodingService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GeocodingService.java
@@ -1,0 +1,62 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.Locale;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult;
+
+@Service
+public class GeocodingService {
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final Logger log = LoggerFactory.getLogger(GeocodingService.class);
+
+    public GeocodingService(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * US #144: Resolve coordinates into LocationResult (City + Country)
+     */
+    public LocationResult resolveLocation(double lat, double lon) {
+        String url = String.format(Locale.US,
+                "https://nominatim.openstreetmap.org/reverse?format=json&lat=%f&lon=%f&zoom=10&addressdetails=1",
+                lat, lon);
+
+        HttpHeaders headers = new HttpHeaders();
+        // Nominatim requires identifying the app
+        headers.set("User-Agent", "SopraGameApp/1.0 (group32@uzh.ch)"); 
+        headers.set("Accept-Language", "en-US,en;q=0.9");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            JsonNode root = objectMapper.readTree(response.getBody());
+            JsonNode address = root.path("address");
+
+            if (address.isMissingNode()) {
+                return new LocationResult("Unknown City", "Unknown Country");
+            }
+
+            String city = address.path("city").asText(
+                            address.path("town").asText(
+                              address.path("village").asText("Unknown City")));
+            
+            String country = address.path("country").asText("Unknown Country");
+
+            return new LocationResult(city, country);
+        } catch (Exception e) {
+            log.error("Geocoding failed for {}, {}: {}", lat, lon, e.getMessage());
+            return new LocationResult("Unknown City", "Unknown Country");
+        }
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MapillaryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/MapillaryService.java
@@ -81,8 +81,9 @@ public class MapillaryService {
     }
 
     public List<String> getImageSequence(double minLon, double minLat, double maxLon, double maxLat, int count) {
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Mapillary API token not configured.");
+        if (accessToken == null || accessToken.isBlank() || accessToken.equals("<MAPILLARY_ACCESS_TOKEN>")) {
+                    log.error("Mapillary API token is missing or invalid.");
+                    throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Mapillary API token is not configured.");
         }
 
         String url = String.format(Locale.US, "%s/images?fields=id,thumb_1024_url,sequence_id&limit=1000&bbox=%f,%f,%f,%f",

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
@@ -35,6 +35,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.AnswerRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.RoundRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.RoundSummaryGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import jakarta.annotation.PostConstruct;
@@ -57,6 +58,8 @@ public class RoundService {
     private final ScoringService scoringService;
     private final Map<String, Round> preloadedRounds = new ConcurrentHashMap<>();
     private final Logger log = LoggerFactory.getLogger(RoundService.class);
+    private final GeocodingService geocodingService;
+
 
 
     // This list will hold all 200+ coordinates in memory for instant access
@@ -87,16 +90,26 @@ public class RoundService {
     }
 
     @Autowired
-    public RoundService(RoundRepository roundRepository, MapillaryService mapillaryService, SimpMessagingTemplate messagingTemplate, LobbyRepository lobbyRepository, UserRepository UserRepository, AnswerRepository answerRepository, ScoringService scoringService) {
-        this.roundRepository = roundRepository;
-        this.mapillaryService = mapillaryService;
-        this.messagingTemplate = messagingTemplate;
-        this.lobbyRepository = lobbyRepository;
-        this.UserRepository = UserRepository;
-        this.answerRepository = answerRepository;
-        this.scoringService = scoringService;
-        this.random = new Random();
-    }
+        public RoundService(
+            RoundRepository roundRepository, 
+            MapillaryService mapillaryService, 
+            SimpMessagingTemplate messagingTemplate, 
+            LobbyRepository lobbyRepository, 
+            UserRepository userRepository,
+            AnswerRepository answerRepository, 
+            ScoringService scoringService,
+            GeocodingService geocodingService 
+        ) {
+            this.roundRepository = roundRepository;
+            this.mapillaryService = mapillaryService;
+            this.messagingTemplate = messagingTemplate;
+            this.lobbyRepository = lobbyRepository;
+            this.UserRepository = userRepository; 
+            this.answerRepository = answerRepository;
+            this.scoringService = scoringService;
+            this.geocodingService = geocodingService; 
+            this.random = new Random();
+        }
 
     // This runs automatically exactly once when Spring Boot starts up
     @PostConstruct
@@ -125,11 +138,17 @@ public class RoundService {
                     5
                 );
 
+                LocationResult location = geocodingService.resolveLocation(
+                    selectedLocation.getLatitude(), selectedLocation.getLongitude()
+                );
+
                 Round preloaded = new Round();
                 preloaded.setLobbyCode(lobbyCode);
                 preloaded.setTargetLatitude(selectedLocation.getLatitude());
                 preloaded.setTargetLongitude(selectedLocation.getLongitude());
                 preloaded.setImageSequence(imageUrls);
+                preloaded.setTargetCity(location.getCity());
+                preloaded.setTargetCountry(location.getCountry());
 
                 preloadedRounds.put(lobbyCode, preloaded);
                 
@@ -196,17 +215,18 @@ public class RoundService {
      * Helper method to reduce code duplication
      */
     private Round tryCreateRound(String lobbyCode, double lat, double lon, double delta) {
-        // No try-catch here anymore! Let the exception bubble up.
-        List<String> imageUrls = mapillaryService.getImageSequence(
-                lon - delta, lat - delta, 
-                lon + delta, lat + delta, 
-                5);
+        List<String> imageUrls = mapillaryService.getImageSequence(lon - delta, lat - delta, lon + delta, lat + delta, 5);
+        
+        // Resolve target names once here
+        LocationResult location = geocodingService.resolveLocation(lat, lon);
 
         Round round = new Round();
         round.setLobbyCode(lobbyCode);
         round.setTargetLatitude(lat);
         round.setTargetLongitude(lon);
         round.setImageSequence(imageUrls);
+        round.setTargetCity(location.getCity()); // Ensure these match the resolved API names
+        round.setTargetCountry(location.getCountry());
         
         return roundRepository.save(round);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ScoringService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ScoringService.java
@@ -2,62 +2,66 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import ch.uzh.ifi.hase.soprafs26.constant.ScoreResult;
 import ch.uzh.ifi.hase.soprafs26.entity.Answer;
 import ch.uzh.ifi.hase.soprafs26.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs26.entity.Round;
 import ch.uzh.ifi.hase.soprafs26.repository.AnswerRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult;
 import ch.uzh.ifi.hase.soprafs26.util.DistanceCalculator;
 
 @Service
 public class ScoringService {
-
-    private static final double CITY_THRESHOLD_KM = 50.0;
-    private static final double COUNTRY_THRESHOLD_KM = 1000.0;
+    private static final Logger log = LoggerFactory.getLogger(ScoringService.class);
     private static final int MAX_POINTS = 2000;
-    private static final int HALF_POINTS = 1000;
+    private static final int COUNTRY_PENALTY_THRESHOLD = 1000;
+
     private final AnswerRepository answerRepository;
     private final LobbyRepository lobbyRepository;
-  
+    private final GeocodingService geocodingService;
+
     @Autowired
-    public ScoringService(AnswerRepository answerRepository, LobbyRepository lobbyRepository) {
+    public ScoringService(AnswerRepository answerRepository, LobbyRepository lobbyRepository, GeocodingService geocodingService) {
         this.answerRepository = answerRepository;
         this.lobbyRepository = lobbyRepository;
+        this.geocodingService = geocodingService;
     }
 
-    public int calculateScore(double guessLat, double guessLng, double targetLat, double targetLng) {
-        double distance = DistanceCalculator.calculateDistanceInKm(guessLat, guessLng, targetLat, targetLng);
+    public int calculateScore(double guessLat, double guessLng, Round round) {
+        double distance = DistanceCalculator.calculateDistanceInKm(guessLat, guessLng, round.getTargetLatitude(), round.getTargetLongitude());
+        LocationResult guessLocation = geocodingService.resolveLocation(guessLat, guessLng);
 
-        if (distance <= CITY_THRESHOLD_KM) {
-            double penalty = (distance / CITY_THRESHOLD_KM) * 500;
-            return MAX_POINTS - (int) penalty;
-
-        } else if (distance <= COUNTRY_THRESHOLD_KM) {
-            double distanceIntoCountry = distance - CITY_THRESHOLD_KM;
-            double countryRange = COUNTRY_THRESHOLD_KM - CITY_THRESHOLD_KM;
-            double penalty = (distanceIntoCountry / countryRange) * HALF_POINTS;
-            return Math.max(0, HALF_POINTS - (int) penalty);
-
-        } else {
-            return 0;
+        // 1. CITY MATCH: Max Points
+        if (guessLocation.getCity().equalsIgnoreCase(round.getTargetCity())) {
+            return MAX_POINTS;
         }
+
+        // 2. COUNTRY MATCH: Partial Points (1000 - 1999 range)
+        if (guessLocation.getCountry().equalsIgnoreCase(round.getTargetCountry())) {
+            int countryScore = (int) Math.max(COUNTRY_PENALTY_THRESHOLD, (MAX_POINTS - 1) - (distance * 0.5));
+            return countryScore;
+        }
+
+        // 3. INCORRECT COUNTRY: Proximity decay (0 - 999 range)
+        int distanceScore = (int) Math.max(0, 800 - (distance * 0.1));
+        return Math.min(COUNTRY_PENALTY_THRESHOLD - 1, distanceScore);
     }
 
-    public ScoreResult getScoreResult(double guessLat, double guessLng, double targetLat, double targetLng) {
-        double distance = DistanceCalculator.calculateDistanceInKm(guessLat, guessLng, targetLat, targetLng);
+    public ScoreResult getScoreResult(double guessLat, double guessLng, Round round) {
+        LocationResult guessLocation = geocodingService.resolveLocation(guessLat, guessLng);
 
-        if (distance <= CITY_THRESHOLD_KM) {
+        if (guessLocation.getCity().equalsIgnoreCase(round.getTargetCity())) {
             return ScoreResult.CORRECT_CITY;
-        } else if (distance <= COUNTRY_THRESHOLD_KM) {
+        } else if (guessLocation.getCountry().equalsIgnoreCase(round.getTargetCountry())) {
             return ScoreResult.CORRECT_COUNTRY;
-        } else {
-            return ScoreResult.INCORRECT;
         }
+        return ScoreResult.INCORRECT;
     }
 
     @Transactional
@@ -68,11 +72,10 @@ public class ScoringService {
         return lobby.getPlayers().stream()
             .map(p -> {
                 int totalScore = answerRepository.findByPlayerIdAndRound_LobbyCode(p.getId(), lobbyCode).stream()
-                    .mapToInt(Answer::getPointsAwarded)
-                    .sum();
+                    .mapToInt(Answer::getPointsAwarded).sum();
                 return new PlayerStanding(p.getId(), p.getUsername(), totalScore);
             })
-            .sorted((a, b) -> b.totalScore - a.totalScore)
+            .sorted((a, b) -> Integer.compare(b.totalScore, a.totalScore))
             .collect(Collectors.toList());
     }
 
@@ -80,7 +83,6 @@ public class ScoringService {
         public final Long playerId;
         public final String username;
         public final int totalScore;
-
         public PlayerStanding(Long playerId, String username, int totalScore) {
             this.playerId = playerId;
             this.username = username;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MapillaryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/MapillaryServiceTest.java
@@ -11,8 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
+
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
@@ -105,21 +108,27 @@ public class MapillaryServiceTest {
      * we would hammer Mapillary with invalid-token requests and
      * pollute their server logs.
      */
-    @Test
-    public void getImageSequence_blankToken_throws500AndDoesNotCallRestTemplate() {
-        // given — token gets wiped after setup
-        ReflectionTestUtils.setField(service, "accessToken", "");
+        @Test
+        public void getImageSequence_blankToken_throws500AndDoesNotCallRestTemplate() {
+                // 1. Force the token to be null for this test
+                ReflectionTestUtils.setField(service, "accessToken", null);
 
-        // when / then
-        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> service.getImageSequence(0.0, 0.0, 1.0, 1.0, 5));
-        assertEquals(500, ex.getStatusCode().value());
+                // 2. Expect a ResponseStatusException to be thrown
+                ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+                service.getImageSequence(8.5, 47.3, 8.6, 47.4, 5);
+                });
 
-        // and critically: no HTTP call was made
-        verify(restTemplate, org.mockito.Mockito.never())
-                .exchange(any(String.class), eq(HttpMethod.GET),
-                          any(HttpEntity.class), eq(String.class));
-    }
+                // 3. Verify it's a 500 error
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
+
+                // 4. Verify that the RestTemplate was NEVER called (since it crashed first)
+                verify(restTemplate, never()).exchange(
+                        anyString(),
+                        eq(HttpMethod.GET),
+                        any(),
+                        eq(String.class)
+                );
+        }
 
     /**
      * US6 #131 — Not-enough-images branch.
@@ -132,22 +141,22 @@ public class MapillaryServiceTest {
      */
     @Test
     public void getImageSequence_notEnoughImages_throws() {
-        // 1. Provide only 3 images
+        // given — response has only 1 image, caller wants 5
         String body = "{\"data\":["
                 + "{\"thumb_1024_url\":\"u1\", \"sequence_id\":\"seq1\"},"
                 + "{\"thumb_1024_url\":\"u2\", \"sequence_id\":\"seq2\"},"
                 + "{\"thumb_1024_url\":\"u3\", \"sequence_id\":\"seq3\"}"
                 + "]}";
+        when(restTemplate.exchange(
+                        any(String.class), 
+                        eq(HttpMethod.GET),
+                        any(HttpEntity.class), 
+                        eq(String.class)
+                )).thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
 
-        // 2. Use the exact same mock matching syntax that passed your first test
-        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET),
-                any(HttpEntity.class), eq(String.class)))
-                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
-
-        // 3. Ask for 5. Pass 3 will catch it and throw the exception!
-        assertThrows(ResponseStatusException.class, () -> {
-            service.getImageSequence(0.0, 0.0, 1.0, 1.0, 5); 
-        });
+        // when / then
+        assertThrows(ResponseStatusException.class,
+                () -> service.getImageSequence(0.0, 0.0, 1.0, 1.0, 5));
     }
 
     /**

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoundServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoundServiceTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -37,6 +39,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.AnswerRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.RoundRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult;
 
 
 /**
@@ -81,6 +84,9 @@ public class RoundServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private GeocodingService geocodingService; // Add this line with the other @Mocks
+
     @InjectMocks
     private RoundService roundService;
 
@@ -95,6 +101,8 @@ public class RoundServiceTest {
     private void seedDataset(RoundService.CuratedLocation... locations) {
         List<RoundService.CuratedLocation> dataset = new ArrayList<>(Arrays.asList(locations));
         ReflectionTestUtils.setField(roundService, "locationsDataset", dataset);
+        when(geocodingService.resolveLocation(anyDouble(), anyDouble()))
+            .thenReturn(new LocationResult("Test City", "Test Country"));
     }
 
     // -------------------------------------------------------------------
@@ -121,6 +129,8 @@ public class RoundServiceTest {
         when(mapillaryService.getImageSequence(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq(5)))
                 .thenReturn(urls);
         when(roundRepository.save(any(Round.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(geocodingService.resolveLocation(anyDouble(), anyDouble()))
+                .thenReturn(new ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult("NYC", "USA"));
 
         // when
         Round round = roundService.createAndStartRound("AB-1234");


### PR DESCRIPTION
- Added GeocodingService to fetch city and country from coordinates
- Updated RoundService to use GeocodingService when preloading rounds
- Updated DTOMapper to include city and country in RoundSummaryGetDTO
- Added LocationResult DTO for geocoding responses
- Updated RoundServiceTest to mock GeocodingService and verify city/country are set
- Updated MapillaryServiceTest to ensure geocoding is not called when token is missing
- Updated build.gradle to include necessary dependencies for geocoding and testing

Close #144