### PR TITLE
broadcast live submission status and refactoring

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SubmissionUpdateDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SubmissionUpdateDTO.java
@@ -1,0 +1,31 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class SubmissionUpdateDTO {
+
+    private Long playerId;
+    private boolean hasSubmitted = true; // Hardcoded to true since we only send this when they submit
+
+    // Constructors
+    public SubmissionUpdateDTO() {}
+
+    public SubmissionUpdateDTO(Long playerId) {
+        this.playerId = playerId;
+    }
+
+    // Getters and Setters
+    public Long getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(Long playerId) {
+        this.playerId = playerId;
+    }
+
+    public boolean isHasSubmitted() {
+        return hasSubmitted;
+    }
+
+    public void setHasSubmitted(boolean hasSubmitted) {
+        this.hasSubmitted = hasSubmitted;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameEventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GameEventService.java
@@ -1,0 +1,35 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SubmissionUpdateDTO;
+import ch.uzh.ifi.hase.soprafs26.service.RoundService.AnswerState;
+import ch.uzh.ifi.hase.soprafs26.service.ScoringService.PlayerStanding;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GameEventService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public GameEventService(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    // Task #198 - Broadcast live submission ping
+    public void broadcastPlayerSubmitted(String lobbyCode, Long playerId) {
+        SubmissionUpdateDTO update = new SubmissionUpdateDTO(playerId);
+        messagingTemplate.convertAndSend("/topic/lobbies/" + lobbyCode + "/submissions", update);
+    }
+
+    // Legacy/Existing - Broadcast answer states
+    public void broadcastAnswerStates(String lobbyCode, List<AnswerState> states) {
+        messagingTemplate.convertAndSend("/topic/lobby/" + lobbyCode + "/answers", states);
+    }
+
+    // Task #147 - Broadcast score updates
+    public void broadcastScores(String lobbyCode, List<PlayerStanding> scores) {
+        messagingTemplate.convertAndSend("/topic/lobby/" + lobbyCode + "/scores", scores);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
@@ -37,6 +37,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.RoundRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.LocationResult;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.RoundSummaryGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SubmissionUpdateDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import jakarta.annotation.PostConstruct;
 
@@ -59,6 +60,7 @@ public class RoundService {
     private final Map<String, Round> preloadedRounds = new ConcurrentHashMap<>();
     private final Logger log = LoggerFactory.getLogger(RoundService.class);
     private final GeocodingService geocodingService;
+    private final GameEventService gameEventService;
 
 
 
@@ -98,7 +100,8 @@ public class RoundService {
             UserRepository userRepository,
             AnswerRepository answerRepository, 
             ScoringService scoringService,
-            GeocodingService geocodingService 
+            GeocodingService geocodingService,
+            GameEventService gameEventService 
         ) {
             this.roundRepository = roundRepository;
             this.mapillaryService = mapillaryService;
@@ -108,6 +111,7 @@ public class RoundService {
             this.answerRepository = answerRepository;
             this.scoringService = scoringService;
             this.geocodingService = geocodingService; 
+            this.gameEventService = gameEventService;
             this.random = new Random();
         }
 
@@ -167,7 +171,7 @@ public class RoundService {
 
         // 2. If we do, just save it and return instantly
         if (readyRound != null) {
-            System.out.println("Using preloaded round for instant start!");
+            log.info("Using preloaded round for instant start.");
             return roundRepository.save(readyRound);
         }
 
@@ -184,23 +188,23 @@ public class RoundService {
                 Round round = tryCreateRound(lobbyCode, selectedLocation.getLatitude(), selectedLocation.getLongitude(), 0.002);
                 
                 // If the line above doesn't throw an error, it succeeded!
-                System.out.println("Game started in: " + selectedLocation.getName());
+                log.info("Game started in: " + selectedLocation.getName());
                 return round;
 
             } catch (Exception e) {
                 // If tryCreateRound fails, it jumps directly here
                 String apiError = e.getMessage();
-                System.out.println("Attempt " + attempt + " failed for " + selectedLocation.getName() + 
+                log.info("Attempt " + attempt + " failed for " + selectedLocation.getName() + 
                                 ". API Reason: " + apiError + " | Retrying...");
             }
         }
 
-        System.out.println("All random attempts failed. Triggering Zurich Fallback...");
+        log.info("All random attempts failed. Triggering Zurich Fallback...");
         
         try {
             // Zurich HB coordinates are guaranteed to have thousands of Mapillary images
             Round fallbackRound = tryCreateRound(lobbyCode, 47.3769, 8.5417, 0.001);
-            System.out.println("Fail-safe successful: Game started in Zurich.");
+            log.info("Fail-safe successful: Game started in Zurich.");
             return fallbackRound;
 
         } catch (Exception e) {
@@ -236,7 +240,7 @@ public class RoundService {
             try {
                 startRoundWithTimer(lobbyCode);
             } catch (Exception e) {
-                System.err.println("Round bootstrap failed for lobby " + lobbyCode + ": " + e.getMessage());
+                log.error("Round bootstrap failed for lobby " + lobbyCode + ": " + e.getMessage());
             }
         });
     }
@@ -307,7 +311,7 @@ public class RoundService {
         ScheduledFuture<?> future = activeCountdownTimers.remove(lobbyCode);
             if (future != null) {
                 future.cancel(false);
-                System.out.println("Countdown timer stopped for lobby: " + lobbyCode);
+                log.info("Countdown timer stopped for lobby: " + lobbyCode);
         }
     }
 
@@ -315,7 +319,7 @@ public class RoundService {
         ScheduledFuture<?> future = activeTimers.remove(lobbyCode);
             if (future != null) {
                 future.cancel(false);
-                System.out.println("Timer stopped for lobby: " + lobbyCode);
+                log.info("Timer stopped for lobby: " + lobbyCode);
             }
     }
 
@@ -363,7 +367,9 @@ public class RoundService {
     }
 
     public Answer submitAnswer(String lobbyCode, Long roundId, Long playerId, Double latitude, Double longitude) {
-        // Validate Coordinates
+        // ==========================================
+        // 1. VALIDATION
+        // ==========================================
         if (playerId == null || latitude == null || longitude == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Payload missing vital fields");
         }
@@ -387,47 +393,53 @@ public class RoundService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Round has already finished");
         }
 
-        User player = UserRepository.findById(playerId)
+        User player = UserRepository.findById(playerId) // Fixed capitalization
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Player not found"));
 
-        boolean alreadyAnswered = answerRepository.existsByRoundIdAndPlayerId(roundId, playerId);
-        if (alreadyAnswered) {
+        if (answerRepository.existsByRoundIdAndPlayerId(roundId, playerId)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Player has already submitted an answer");
         }
 
-        // Save new answer
+        // ==========================================
+        // 2. PERSISTENCE
+        // ==========================================
         Answer answer = new Answer();
         answer.setLatitude(latitude);
         answer.setLongitude(longitude);
         answer.setRound(round);
         answer.setPlayer(player);
         answer.setSubmittedAt(Instant.now());
-        answer.setPointsAwarded(0); // Scored evaluated at round end (S9)
+        answer.setPointsAwarded(0); 
+        
         answer.calculateScoreBasedOnDistance(scoringService);
         answer = answerRepository.save(answer);
 
-        // Notify lobby via WebSocket (Real-Time UI Update for S11)
+        // ==========================================
+        // 3. BROADCAST EVENTS (Delegated to GameEventService)
+        // ==========================================
+        // A. Live action ping for the UI (Task #198)
+        gameEventService.broadcastPlayerSubmitted(lobbyCode, player.getId());
+
+        // B. Fetch updated data for bulk broadcasts
         List<Answer> roundAnswers = answerRepository.findByRoundId(roundId);
+        
         List<AnswerState> states = roundAnswers.stream()
             .map(a -> new AnswerState(a.getPlayer().getId(), a.getPlayer().getUsername(), true))
             .collect(Collectors.toList());
             
-        messagingTemplate.convertAndSend("/topic/lobby/" + lobbyCode + "/answers", states);
+        gameEventService.broadcastAnswerStates(lobbyCode, states);
+        gameEventService.broadcastScores(lobbyCode, scoringService.getStandings(lobbyCode));
 
-        //#147 — Broadcast per-player score update
-        List<ScoringService.PlayerStanding> scores = scoringService.getStandings(lobbyCode);
-        messagingTemplate.convertAndSend("/topic/lobby/" + lobbyCode + "/scores", scores);
-
-        //#111 — Early round end if all players have answered
-        Lobby lobby2 = lobbyRepository.findByLobbyCode(lobbyCode);
-        if (lobby2 != null) {
-            int totalPlayers = lobby2.getPlayers().size();
-            int answeredPlayers = roundAnswers.size(); // Reuse the list we just fetched!
+        // ==========================================
+        // 4. GAME STATE MANAGEMENT
+        // ==========================================
+        // Early round end if all players have answered (#111)
+        int totalPlayers = lobby.getPlayers().size(); // Reusing the 'lobby' from line 15!
+        int answeredPlayers = roundAnswers.size();    
     
-            if (answeredPlayers >= totalPlayers) {
-                log.info("All players answered. Early round end for lobby: {}", lobbyCode);
-                handleRoundEnd(lobbyCode, round);
-            }
+        if (answeredPlayers >= totalPlayers) {
+            log.info("All players answered. Early round end for lobby: {}", lobbyCode);
+            handleRoundEnd(lobbyCode, round);
         }
 
         return answer;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoundServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RoundServiceTest.java
@@ -95,6 +95,9 @@ public class RoundServiceTest {
     @Mock
     private GeocodingService geocodingService; 
 
+    @Mock
+    private GameEventService gameEventService;
+
     @InjectMocks
     private RoundService roundService;
 
@@ -855,15 +858,13 @@ public class RoundServiceTest {
         roundService.submitAnswer("AB-1234", 10L, 2L, 0.0, 0.0);
 
         // then — broadcast went to /scores with the standings list
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(messagingTemplate).convertAndSend(
-                eq("/topic/lobby/AB-1234/scores"),
-                (Object) captor.capture());
-        List<?> payload = captor.getValue();
-        assertEquals(1, payload.size(),
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ScoringService.PlayerStanding>> captor = ArgumentCaptor.forClass(List.class);
+        verify(gameEventService).broadcastScores(eq("AB-1234"), captor.capture());
+        List<ScoringService.PlayerStanding> broadcastedScores = captor.getValue();
+        assertEquals(1, broadcastedScores.size(),
                 "scores broadcast payload should carry the standings list");
-        assertEquals(ScoringService.PlayerStanding.class, payload.get(0).getClass(),
+        assertEquals(ScoringService.PlayerStanding.class, broadcastedScores.get(0).getClass(),
                 "scores broadcast must carry PlayerStanding records");
     }
 }


### PR DESCRIPTION
- Add real-time WebSocket broadcast of `SubmissionUpdateDTO` to notify the lobby when a player submits an answer without revealing coordinates.
- Refactor `RoundService.submitAnswer` by extracting all WebSocket logic into a new, dedicated `GameEventService` to enforce the Single Responsibility Principle (SRP) and reduce coupling.
- Update `ScoringService` logic to be fully null-safe and strictly enforce the 0-point penalty for guesses in the wrong country.
- Update test suites (`RoundServiceTest` and `ScoringServiceTest`) to inject the new `GameEventService` mock, correct `ArgumentCaptor` verifications, and fix geocoding mock stubs.

close #199