### PR TITLE
add submission state recovery for mid-round refresh

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Round.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Round.java
@@ -33,6 +33,9 @@ public class Round {
     @Column
     private String targetCountry;
 
+    @Transient
+    private List<Long> submittedPlayerIds = new ArrayList<>();
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "ROUND_IMAGES", joinColumns = @JoinColumn(name = "round_id"))
     @Column(name = "image_url", length = 1000) // URLs can be long
@@ -41,20 +44,31 @@ public class Round {
     // Getters and Setters
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+
     public String getLobbyCode() { return lobbyCode; }
     public void setLobbyCode(String lobbyCode) { this.lobbyCode = lobbyCode; }
+
     public double getTargetLatitude() { return targetLatitude; }
     public void setTargetLatitude(double targetLatitude) { this.targetLatitude = targetLatitude; }
+
     public double getTargetLongitude() { return targetLongitude; }
     public void setTargetLongitude(double targetLongitude) { this.targetLongitude = targetLongitude; }
+
     public List<String> getImageSequence() { return imageSequence; }
     public void setImageSequence(List<String> imageSequence) { this.imageSequence = imageSequence; }
+
     public boolean isFinished() { return finished; }
     public void setFinished(boolean finished) { this.finished = finished; }
+
     public Instant getStartedAt() { return startedAt; }
     public void setStartedAt(Instant startedAt) { this.startedAt = startedAt; }
+
     public String getTargetCity() { return targetCity; }
     public void setTargetCity(String targetCity) { this.targetCity = targetCity; }
+
     public String getTargetCountry() { return targetCountry; }
     public void setTargetCountry(String targetCountry) { this.targetCountry = targetCountry; }
+
+    public List<Long> getSubmittedPlayerIds() {return submittedPlayerIds;}
+    public void setSubmittedPlayerIds(List<Long> submittedPlayerIds) {this.submittedPlayerIds = submittedPlayerIds;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RoundSummaryGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RoundSummaryGetDTO.java
@@ -10,6 +10,7 @@ public class RoundSummaryGetDTO {
     private String correctCountry;
     private Double correctLatitude;
     private Double correctLongitude;
+    private List<Long> submittedPlayerIds;
     
     private List<PlayerStanding> standings;
 
@@ -30,4 +31,7 @@ public class RoundSummaryGetDTO {
 
     public List<PlayerStanding> getStandings() { return standings; }
     public void setStandings(List<PlayerStanding> standings) { this.standings = standings; }
+
+    public List<Long> getSubmittedPlayerIds() {return submittedPlayerIds;}
+    public void setSubmittedPlayerIds(List<Long> submittedPlayerIds) {this.submittedPlayerIds = submittedPlayerIds;}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
@@ -507,7 +507,22 @@ public class RoundService {
         if (!round.getLobbyCode().equals(lobbyCode)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Round does not belong to this lobby");
         }
+
+        // -----------------------------------------------------------------
+        // TASK #199: Fetch answers and extract player IDs for the frontend
+        // -----------------------------------------------------------------
+        List<Answer> answers = answerRepository.findByRoundId(roundId);
+        
+        List<Long> submittedIds = answers.stream()
+            .map(answer -> answer.getPlayer().getId())
+            .collect(Collectors.toList());
+            
+        // Set the transient field so DTOMapper can automatically pick it up
+        round.setSubmittedPlayerIds(submittedIds);
+        // -----------------------------------------------------------------
+
         List<ScoringService.PlayerStanding> standings = scoringService.getStandings(lobbyCode);
+        
         return DTOMapper.INSTANCE.convertToRoundSummaryGetDTO(round, standings);
     }
 }


### PR DESCRIPTION
- Add `@Transient` `submittedPlayerIds` field to the `Round` entity.
- Update `RoundSummaryGetDTO` to expose the list of submitted players to the client.
- Modify `RoundService.getRoundSummary` to dynamically query the `AnswerRepository` and inject the IDs of players who have already submitted.
- Ensure frontend UI can accurately restore the "green background" status for players if they refresh their browser or lose WebSocket connection mid-round.

close #199