### PR TITLE
handle player disconnects + resolve context crash

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/RoundRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/RoundRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository("roundRepository")
 public interface RoundRepository extends JpaRepository<Round, Long> {
     List<Round> findByLobbyCode(String lobbyCode);
+    Round findTopByLobbyCodeOrderByIdDesc(String lobbyCode);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LobbyService.java
@@ -201,4 +201,25 @@ public class LobbyService {
         log.debug("Game started in lobby: {}", lobbyCode);
         return lobby;
     }
+
+    @Transactional
+    public void handleDisconnect(String lobbyCode, Long userId) {
+        Lobby lobby = lobbyRepository.findByLobbyCode(lobbyCode);
+        if (lobby == null) return; // Fail silently, the lobby might already be deleted
+
+        // We don't care if the game is INGAME or WAITING, if they disconnect, remove them!
+        boolean isPlayerInLobby = lobby.getPlayers().stream().anyMatch(p -> p.getId().equals(userId));
+        
+        if (isPlayerInLobby) {
+            removePlayer(lobby, userId); // Use your existing helper method!
+            lobbyRepository.save(lobby);
+            lobbyRepository.flush();
+        }
+    }
+
+    public String getLobbyCodeByUserId(Long userId) {
+        return lobbyRepository.findByPlayers_Id(userId)
+                .map(Lobby::getLobbyCode)
+                .orElse(null);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RoundService.java
@@ -433,17 +433,11 @@ public class RoundService {
         // ==========================================
         // 4. GAME STATE MANAGEMENT
         // ==========================================
-        // Early round end if all players have answered (#111)
-        int totalPlayers = lobby.getPlayers().size(); // Reusing the 'lobby' from line 15!
-        int answeredPlayers = roundAnswers.size();    
-    
-        if (answeredPlayers >= totalPlayers) {
-            log.info("All players answered. Early round end for lobby: {}", lobbyCode);
-            handleRoundEnd(lobbyCode, round);
-        }
+        checkAndHandleEarlyRoundEnd(lobbyCode, round);
 
         return answer;
     }
+
 
     /**
      * Centralized logic to handle the end of a round, whether by timer or all players answering.
@@ -524,5 +518,18 @@ public class RoundService {
         List<ScoringService.PlayerStanding> standings = scoringService.getStandings(lobbyCode);
         
         return DTOMapper.INSTANCE.convertToRoundSummaryGetDTO(round, standings);
+    }
+
+    public void checkAndHandleEarlyRoundEnd(String lobbyCode, Round currentRound) {
+        Lobby lobby = lobbyRepository.findByLobbyCode(lobbyCode);
+        if (lobby == null || currentRound == null) return;
+
+        int totalPlayers = lobby.getPlayers().size(); // Now updated if someone left
+        int answeredPlayers = answerRepository.findByRoundId(currentRound.getId()).size();
+
+        if (totalPlayers > 0 && answeredPlayers >= totalPlayers) {
+            log.info("All active players answered (or remaining players after a disconnect). Ending round early for lobby: {}", lobbyCode);
+            handleRoundEnd(lobbyCode, currentRound);
+        }
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ScoringService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ScoringService.java
@@ -44,8 +44,7 @@ public class ScoringService {
 
         // 2. COUNTRY MATCH: Partial Points (1000 - 1999 range)
         if (guessLocation.getCountry().equalsIgnoreCase(round.getTargetCountry())) {
-            int countryScore = (int) Math.max(COUNTRY_PENALTY_THRESHOLD, (MAX_POINTS - 1) - (distance * 0.5));
-            return countryScore;
+            return (int) Math.max(COUNTRY_PENALTY_THRESHOLD, (MAX_POINTS - 1) - (distance * 0.5));
         }
 
         // 3. INCORRECT COUNTRY: Proximity decay (0 - 999 range)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WebSocketSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/WebSocketSessionService.java
@@ -1,13 +1,22 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import ch.uzh.ifi.hase.soprafs26.repository.LobbyRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.Lobby;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 
+
 @Service
 public class WebSocketSessionService {
     private final Map<String, Long> sessionToUserMap = new ConcurrentHashMap<>();
+    private final LobbyRepository lobbyRepository;
+
+    public WebSocketSessionService(LobbyRepository lobbyRepository) {
+        this.lobbyRepository = lobbyRepository;
+    }
 
     public void pair(String sessionId, Long userId) {
         sessionToUserMap.put(sessionId, userId);
@@ -15,6 +24,16 @@ public class WebSocketSessionService {
 
     public Long getUserId(String sessionId) {
         return sessionToUserMap.get(sessionId);
+    }
+
+    public String getLobbyCodeBySession(String sessionId) {
+        Long userId = sessionToUserMap.get(sessionId);
+        if (userId != null) {
+            return lobbyRepository.findByPlayers_Id(userId)
+                    .map(Lobby::getLobbyCode)
+                    .orElse(null);
+        }
+        return null;
     }
 
     public void remove(String sessionId) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListener.java
@@ -1,21 +1,66 @@
 package ch.uzh.ifi.hase.soprafs26.websocket;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Round;
 import ch.uzh.ifi.hase.soprafs26.service.WebSocketSessionService;
+import ch.uzh.ifi.hase.soprafs26.repository.RoundRepository;
+import ch.uzh.ifi.hase.soprafs26.service.RoundService;
+import ch.uzh.ifi.hase.soprafs26.service.LobbyService;
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class WebSocketEventListener {
 
-    private final WebSocketSessionService sessionService;
+    private static final Logger log = LoggerFactory.getLogger(WebSocketEventListener.class);
+    
+    // 1. Declare your dependencies once, nicely named with lowercase first letters
+    private final WebSocketSessionService webSocketSessionService;
+    private final RoundRepository roundRepository;
+    private final RoundService roundService;
+    private final LobbyService lobbyService;
 
-    public WebSocketEventListener(WebSocketSessionService sessionService) {
-        this.sessionService = sessionService;
+    // 2. Inject ALL of them via the constructor
+    public WebSocketEventListener(
+            WebSocketSessionService webSocketSessionService,
+            RoundRepository roundRepository,
+            RoundService roundService,
+            LobbyService lobbyService) {
+        this.webSocketSessionService = webSocketSessionService;
+        this.roundRepository = roundRepository;
+        this.roundService = roundService;   
+        this.lobbyService = lobbyService;
     }
 
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-        sessionService.remove(event.getSessionId());
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+
+        // 3. Call the methods on your properly injected instance
+        Long userId = webSocketSessionService.getUserId(sessionId); // Ensure this matches your actual method name (maybe getUserIdBySession?)
+        String lobbyCode = webSocketSessionService.getLobbyCodeBySession(sessionId);
+
+        if (userId != null && lobbyCode != null) {
+            log.info("User {} disconnected from Lobby {}", userId, lobbyCode);
+
+            // Remove the player from the lobby
+            lobbyService.handleDisconnect(lobbyCode, userId);
+
+            // Find the current active round for this lobby
+            Round currentRound = roundRepository.findTopByLobbyCodeOrderByIdDesc(lobbyCode);
+
+            if (currentRound != null && !currentRound.isFinished()) {
+                // Trigger the check! 
+                roundService.checkAndHandleEarlyRoundEnd(lobbyCode, currentRound);
+            }
+
+            // Cleanup the session tracker
+            webSocketSessionService.remove(sessionId); // Ensure this matches your actual method name (maybe removeSession?)
+        }
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListener.java
@@ -42,7 +42,7 @@ public class WebSocketEventListener {
         String sessionId = headerAccessor.getSessionId();
 
         // 3. Call the methods on your properly injected instance
-        Long userId = webSocketSessionService.getUserId(sessionId); // Ensure this matches your actual method name (maybe getUserIdBySession?)
+        Long userId = webSocketSessionService.getUserId(sessionId);
         String lobbyCode = webSocketSessionService.getLobbyCodeBySession(sessionId);
 
         if (userId != null && lobbyCode != null) {
@@ -60,7 +60,7 @@ public class WebSocketEventListener {
             }
 
             // Cleanup the session tracker
-            webSocketSessionService.remove(sessionId); // Ensure this matches your actual method name (maybe removeSession?)
+            webSocketSessionService.remove(sessionId); 
         }
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListenerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketEventListenerTest.java
@@ -1,6 +1,9 @@
 package ch.uzh.ifi.hase.soprafs26.websocket;
 
 import ch.uzh.ifi.hase.soprafs26.service.WebSocketSessionService;
+import ch.uzh.ifi.hase.soprafs26.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs26.service.RoundService;
+import ch.uzh.ifi.hase.soprafs26.repository.RoundRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +11,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 /**
@@ -27,8 +35,13 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
  */
 public class WebSocketEventListenerTest {
 
-    @Mock
-    private WebSocketSessionService sessionService;
+    @Mock private WebSocketSessionService sessionService;
+
+    @Mock private LobbyService lobbyService;
+
+    @Mock private RoundService roundService;
+
+    @Mock private RoundRepository roundRepository;
 
     @InjectMocks
     private WebSocketEventListener listener;
@@ -54,16 +67,28 @@ public class WebSocketEventListenerTest {
      */
     @Test
     public void handleWebSocketDisconnectListener_removesSessionFromSessionService() {
-        // given — a disconnect event carrying a known session id
-        SessionDisconnectEvent event = Mockito.mock(SessionDisconnectEvent.class);
-        Mockito.when(event.getSessionId()).thenReturn("session-42");
+        // 1. Create Stomp headers containing the target session ID
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+        accessor.setSessionId("session-42");
 
-        // when — Spring would call this via @EventListener; we invoke it directly
+        // 2. Wrap the headers in a standard Spring Message
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        // 3. Create the event using that message
+        SessionDisconnectEvent event = new SessionDisconnectEvent(this, message, "session-42", CloseStatus.NORMAL);
+
+        // 4. Stub the session service so it passes the 'if (userId != null)' check
+        Mockito.when(sessionService.getUserId("session-42")).thenReturn(1L);
+        Mockito.when(sessionService.getLobbyCodeBySession("session-42")).thenReturn("AB-1234");
+        
+        // Stub the repository to return null just to prevent null pointers
+        Mockito.when(roundRepository.findTopByLobbyCodeOrderByIdDesc("AB-1234")).thenReturn(null);
+
+        // 5. Act
         listener.handleWebSocketDisconnectListener(event);
 
-        // then — the session service had remove invoked with the exact session id
+        // 6. Assert that the cleanup logic ran properly
         Mockito.verify(sessionService).remove("session-42");
-        // and nothing else (no lobby, no broadcast — that's by design)
-        Mockito.verifyNoMoreInteractions(sessionService);
+        Mockito.verify(lobbyService).handleDisconnect("AB-1234", 1L);
     }
 }


### PR DESCRIPTION
- Update `WebSocketEventListener` to catch session drops, remove the player, and trigger early round-end checks to prevent hanging games.
- Implement `handleDisconnect` in `LobbyService` to silently remove disconnected players without throwing REST-specific HTTP exceptions.
- Resolve Spring circular dependency by refactoring `WebSocketSessionService` to query `LobbyRepository` directly instead of injecting `LobbyService`.
- Fix application context initialization crash by correcting the `RoundRepository` query to `findTopByLobbyCodeOrderByIdDesc`.
- Update `WebSocketEventListenerTest` to properly simulate STOMP headers using `MessageBuilder` and verify correct event delegation.

Close #200